### PR TITLE
🔀 :: (#75) - post page 통신을 위한 세팅

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/post/request/PostModifyRequestModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/post/request/PostModifyRequestModel.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.model.post.request
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+
+data class PostModifyRequestModel (
+    val type: Type,
+    val mode: Mode,
+    val title: String,
+    val content: String,
+    val gwangsan: Number,
+    val imageIds: List<Number>
+)

--- a/core/model/src/main/java/com/school_of_company/model/post/request/PostWriteRequestModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/post/request/PostWriteRequestModel.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.model.post.request
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+
+data class PostWriteRequestModel (
+    val type: Type,
+    val mode: Mode,
+    val title: String,
+    val content: String,
+    val gwangsan: Int,
+    val imageIds: List<Number>
+)

--- a/core/model/src/main/java/com/school_of_company/model/post/response/PostModifyResponseModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/post/response/PostModifyResponseModel.kt
@@ -1,0 +1,5 @@
+package com.school_of_company.model.post.response
+
+data class PostModifyResponseModel (
+    val message: String
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/PostAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/PostAPI.kt
@@ -1,0 +1,29 @@
+package com.school_of_company.network.api
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+import com.school_of_company.network.dto.post.request.PostWriteRequest
+import com.school_of_company.network.dto.post.response.PostModifyResponse
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface PostAPI {
+
+    @POST("/api/post")
+    suspend fun writePostInformation(
+        @Header("Authorization") token: String,
+        @Query("type") type: Type,
+        @Query("mode") mode: Mode,
+        @Body request: PostWriteRequest
+    )
+
+    @POST("/api/post/modify")
+    suspend fun modifyPostInformation(
+        @Header("Authorization") token: String,
+        @Query("type") type: Type,
+        @Query("mode") mode: Mode,
+        @Body request: PostWriteRequest
+    ): PostModifyResponse
+}

--- a/core/network/src/main/java/com/school_of_company/network/datasource/post/PostDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/post/PostDataSource.kt
@@ -1,0 +1,24 @@
+package com.school_of_company.network.datasource.post
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+import com.school_of_company.network.dto.post.request.PostWriteRequest
+import com.school_of_company.network.dto.post.response.PostModifyResponse
+import kotlinx.coroutines.flow.Flow
+
+interface PostDataSource {
+
+    fun writePostInformation(
+        token: String,
+        type: Type,
+        mode: Mode,
+        request: PostWriteRequest
+    ): Flow<Unit>
+
+    fun modifyPostInformation(
+        token: String,
+        type: Type,
+        mode: Mode,
+        request: PostWriteRequest
+    ): Flow<PostModifyResponse>
+}

--- a/core/network/src/main/java/com/school_of_company/network/datasource/post/PostDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/post/PostDataSourceImpl.kt
@@ -1,0 +1,35 @@
+package com.school_of_company.network.datasource.post
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+import com.school_of_company.network.api.PostAPI
+import com.school_of_company.network.dto.post.request.PostWriteRequest
+import com.school_of_company.network.dto.post.response.PostModifyResponse
+import com.school_of_company.network.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class PostDataSourceImpl @Inject constructor(
+    private val postAPI: PostAPI
+) : PostDataSource {
+
+    override fun writePostInformation(
+        token: String,
+        type: Type,
+        mode: Mode,
+        request: PostWriteRequest
+    ): Flow<Unit> =
+        performApiRequest {
+            postAPI.writePostInformation(token, type, mode, request)
+        }
+
+    override fun modifyPostInformation(
+        token: String,
+        type: Type,
+        mode: Mode,
+        request: PostWriteRequest
+    ): Flow<PostModifyResponse> =
+        performApiRequest {
+            postAPI.modifyPostInformation(token, type, mode, request)
+        }
+}

--- a/core/network/src/main/java/com/school_of_company/network/dto/post/request/PostModifyRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/post/request/PostModifyRequest.kt
@@ -1,0 +1,16 @@
+package com.school_of_company.network.dto.post.request
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostModifyRequest(
+    @Json(name = "type") val type: Type,
+    @Json(name = "mode") val mode: Mode,
+    @Json(name = "title") val title: String,
+    @Json(name = "content") val content: String,
+    @Json(name = "gwangsan") val gwangsan: Number,
+    @Json(name = "imageIds") val imageIds: List<Number>
+)

--- a/core/network/src/main/java/com/school_of_company/network/dto/post/request/PostWriteRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/post/request/PostWriteRequest.kt
@@ -1,0 +1,16 @@
+package com.school_of_company.network.dto.post.request
+
+import com.school_of_company.model.enum.Mode
+import com.school_of_company.model.enum.Type
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostWriteRequest(
+    @Json(name = "type") val type: Type,
+    @Json(name = "mode") val mode: Mode,
+    @Json(name = "title") val title: String,
+    @Json(name = "content") val content: String,
+    @Json(name = "gwangsan") val gwangsan: Int,
+    @Json(name = "imageIds") val imageIds: List<Number>
+)

--- a/core/network/src/main/java/com/school_of_company/network/dto/post/response/PostModifyResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/post/response/PostModifyResponse.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.network.dto.post.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PostModifyResponse (
+    @Json(name = "message") val message: String
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/post/request/PostModifyRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/post/request/PostModifyRequestMapper.kt
@@ -1,0 +1,14 @@
+package com.school_of_company.network.mapper.post.request
+
+import com.school_of_company.model.post.request.PostModifyRequestModel
+import com.school_of_company.network.dto.post.request.PostModifyRequest
+
+fun PostModifyRequestModel.toDto(): PostModifyRequest
+= PostModifyRequest (
+    type = type,
+    mode = mode,
+    title = title,
+    content = content,
+    gwangsan = gwangsan,
+    imageIds = imageIds
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/post/request/PostWriteRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/post/request/PostWriteRequestMapper.kt
@@ -1,0 +1,14 @@
+package com.school_of_company.network.mapper.post.request
+
+import com.school_of_company.model.post.request.PostWriteRequestModel
+import com.school_of_company.network.dto.post.request.PostWriteRequest
+
+fun PostWriteRequestModel.toDto(): PostWriteRequest
+= PostWriteRequest (
+    type = type,
+    mode = mode,
+    title = title,
+    content = content,
+    gwangsan = gwangsan,
+    imageIds = imageIds
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/post/response/PostModifyResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/post/response/PostModifyResponseMapper.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.network.mapper.post.response
+
+import com.school_of_company.model.post.response.PostModifyResponseModel
+import com.school_of_company.network.dto.post.response.PostModifyResponse
+
+fun PostModifyResponse.toModel(): PostModifyResponseModel
+ = PostModifyResponseModel(
+    message = message
+)


### PR DESCRIPTION
## 💡 개요
post page 통신을 위한 세팅
## 📃 작업내용
add PostAPI
add DataSource
add Model
add Mapper
add request, response
## 🔀 변경사항
![image](https://github.com/user-attachments/assets/582e0533-3df1-46df-ac31-c9083ac4fb8e)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타