### PR TITLE
🔀 :: (#143) - 공지, 메인 시작 화면에서 지점명을 표시해주었습니다.

### DIFF
--- a/feature/inform/src/main/java/com/school_of_company/inform/view/InformScreen.kt
+++ b/feature/inform/src/main/java/com/school_of_company/inform/view/InformScreen.kt
@@ -23,7 +23,9 @@ import com.school_of_company.design_system.theme.GwangSanTheme
 import com.school_of_company.inform.component.InformList
 import com.school_of_company.inform.viewmodel.NoticeViewModel
 import com.school_of_company.inform.viewmodel.uistate.GetAllNoticeUiState
+import com.school_of_company.inform.viewmodel.uistate.MemberUiState
 import com.school_of_company.model.notice.response.GetAllNoticeResponseModel
+import com.school_of_company.model.post.response.Member
 import com.school_of_company.ui.previews.GwangsanPreviews
 
 @Composable
@@ -35,16 +37,19 @@ internal fun InformRoute(
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
     val getAllNoticeUiState by viewModel.getAllNoticeUiState.collectAsStateWithLifecycle()
+    val getMyProfileUiState by viewModel.getMyProfileUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.getAllNotice()
+        viewModel.getMyProfile()
     }
 
     InformScreen(
         swipeRefreshState = swipeRefreshState,
         getAllNotice = { viewModel.getAllNotice() },
         informList = getAllNoticeUiState,
-        onNextClick = onNextClick
+        onNextClick = onNextClick,
+        getMyProfileUiState = getMyProfileUiState
     )
 }
 
@@ -54,6 +59,7 @@ private fun InformScreen(
     swipeRefreshState: SwipeRefreshState,
     getAllNotice: () -> Unit,
     informList: GetAllNoticeUiState,
+    getMyProfileUiState: MemberUiState,
     onNextClick: (Long) -> Unit
 ) {
     GwangSanTheme { colors, typography ->
@@ -75,19 +81,55 @@ private fun InformScreen(
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            Text(
-                text = "신가지점 공지입니다",
-                style = typography.titleMedium2,
-                color = colors.black
-            )
+            when (getMyProfileUiState) {
+                is MemberUiState.Loading -> {
+                    Text(
+                        text = "지점명 가져오는 중..",
+                        style = typography.titleMedium2,
+                        color = colors.black
+                    )
 
-            Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
 
-            Text(
-                text = "신가",
-                style = typography.body5,
-                color = colors.gray400,
-            )
+                    Text(
+                        text = "지점명 가져오는 중..",
+                        style = typography.body5,
+                        color = colors.gray400,
+                    )
+                }
+
+                is MemberUiState.Success -> {
+                    Text(
+                        text = "${getMyProfileUiState.data.placeName} 공지입니다",
+                        style = typography.titleMedium2,
+                        color = colors.black
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = getMyProfileUiState.data.placeName,
+                        style = typography.body5,
+                        color = colors.gray400,
+                    )
+                }
+
+                is MemberUiState.Error -> {
+                    Text(
+                        text = "지점을 찾을 수 없습니다..",
+                        style = typography.titleMedium2,
+                        color = colors.black
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = "지점을 찾을 수 없습니다..",
+                        style = typography.body5,
+                        color = colors.gray400,
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(24.dp))
 
@@ -167,6 +209,7 @@ private fun InformScreenPreview() {
         onNextClick = {},
         swipeRefreshState = SwipeRefreshState(isRefreshing = false),
         getAllNotice = {},
-        modifier = Modifier
+        modifier = Modifier,
+        getMyProfileUiState = MemberUiState.Loading
     )
 }

--- a/feature/inform/src/main/java/com/school_of_company/inform/viewmodel/NoticeViewModel.kt
+++ b/feature/inform/src/main/java/com/school_of_company/inform/viewmodel/NoticeViewModel.kt
@@ -2,9 +2,11 @@ package com.school_of_company.inform.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.school_of_company.data.repository.member.MemberRepository
 import com.school_of_company.data.repository.notice.NoticeRepository
 import com.school_of_company.inform.viewmodel.uistate.GetAllNoticeUiState
 import com.school_of_company.inform.viewmodel.uistate.GetSpecificNoticeUiState
+import com.school_of_company.inform.viewmodel.uistate.MemberUiState
 import com.school_of_company.result.Result
 import com.school_of_company.result.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class NoticeViewModel @Inject constructor(
-    private val noticeRepository: NoticeRepository
+    private val noticeRepository: NoticeRepository,
+    private val memberRepository: MemberRepository
 ) : ViewModel() {
 
     private val _getAllNoticeUiState = MutableStateFlow<GetAllNoticeUiState>(GetAllNoticeUiState.Loading)
@@ -24,6 +27,9 @@ class NoticeViewModel @Inject constructor(
 
     private val _getSpecificNoticeUiState = MutableStateFlow<GetSpecificNoticeUiState>(GetSpecificNoticeUiState.Loading)
     internal val getSpecificNoticeUiState = _getSpecificNoticeUiState.asStateFlow()
+
+    private val _getMyProfileUiState = MutableStateFlow<MemberUiState>(MemberUiState.Loading)
+    internal val getMyProfileUiState = _getMyProfileUiState.asStateFlow()
 
     private val _swipeRefreshLoading = MutableStateFlow(false)
     val swipeRefreshLoading = _swipeRefreshLoading.asStateFlow()
@@ -64,6 +70,18 @@ class NoticeViewModel @Inject constructor(
                     is Result.Loading -> _getSpecificNoticeUiState.value = GetSpecificNoticeUiState.Loading
                     is Result.Success -> _getSpecificNoticeUiState.value = GetSpecificNoticeUiState.Success(result.data)
                     is Result.Error -> _getSpecificNoticeUiState.value = GetSpecificNoticeUiState.Error(result.exception)
+                }
+            }
+    }
+
+    internal fun getMyProfile() = viewModelScope.launch {
+        memberRepository.getMyProfileInformation()
+            .asResult()
+            .collectLatest { result ->
+                when (result) {
+                    is Result.Loading -> _getMyProfileUiState.value = MemberUiState.Loading
+                    is Result.Success -> _getMyProfileUiState.value = MemberUiState.Success(result.data)
+                    is Result.Error -> _getMyProfileUiState.value = MemberUiState.Error(result.exception)
                 }
             }
     }

--- a/feature/inform/src/main/java/com/school_of_company/inform/viewmodel/uistate/MemberUiState.kt
+++ b/feature/inform/src/main/java/com/school_of_company/inform/viewmodel/uistate/MemberUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.inform.viewmodel.uistate
+
+import com.school_of_company.model.member.response.GetMemberResponseModel
+
+interface MemberUiState {
+    data object Loading : MemberUiState
+    data class Success(val data: GetMemberResponseModel) : MemberUiState
+    data class Error(val exception: Throwable) : MemberUiState
+}

--- a/feature/main/src/main/java/com/school_of_company/main/view/MainStartScreen.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/view/MainStartScreen.kt
@@ -1,6 +1,5 @@
 package com.school_of_company.main.view
 
-import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -22,11 +21,14 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.componet.clickable.GwangSanClickable
 import com.school_of_company.design_system.componet.icons.BellIcon
@@ -36,6 +38,8 @@ import com.school_of_company.design_system.componet.icons.ServiceIcon
 import com.school_of_company.design_system.componet.topbar.GwangSanSubTopBar
 import com.school_of_company.design_system.theme.GwangSanTheme
 import com.school_of_company.main.component.MainButton
+import com.school_of_company.main.viewmodel.MainViewModel
+import com.school_of_company.main.viewmodel.uistate.MemberUiState
 import com.school_of_company.ui.previews.GwangsanPreviews
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -44,10 +48,19 @@ import kotlinx.coroutines.launch
 internal fun MainStartRoute(
     navigationToService: () -> Unit,
     navigationToObject: () -> Unit,
+    viewModel: MainViewModel = hiltViewModel()
 ) {
+
+    val getMyProfileUiState by viewModel.myProfileUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.getMyProfile()
+    }
+
     MainStartScreen(
         navigationToService = navigationToService,
         navigationToObject = navigationToObject,
+        getMyProfileUiState = getMyProfileUiState
     )
 }
 
@@ -56,6 +69,7 @@ private fun MainStartScreen(
     modifier: Modifier = Modifier,
     navigationToService: () -> Unit,
     navigationToObject: () -> Unit,
+    getMyProfileUiState: MemberUiState
 ) {
     GwangSanTheme { colors, typography ->
 
@@ -132,11 +146,31 @@ private fun MainStartScreen(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                Text(
-                    text = "신가",
-                    style = typography.body4,
-                    color = colors.black
-                )
+                when (getMyProfileUiState) {
+                    is MemberUiState.Loading -> {
+                        Text(
+                            text = "로딩중..",
+                            style = typography.body4,
+                            color = colors.gray500
+                        )
+                    }
+
+                    is MemberUiState.Success -> {
+                        Text(
+                            text = getMyProfileUiState.data.placeName,
+                            style = typography.body4,
+                            color = colors.black
+                        )
+                    }
+
+                    is MemberUiState.Error -> {
+                        Text(
+                            text = "요청 실패..",
+                            style = typography.body4,
+                            color = colors.gray500
+                        )
+                    }
+                }
 
                 Spacer(modifier = Modifier.padding(bottom = 62.dp))
 
@@ -205,6 +239,7 @@ fun MainStartScreenPreview() {
     MainStartScreen(
         navigationToService = {},
         navigationToObject = {},
+        getMyProfileUiState = MemberUiState.Loading
     )
 }
 

--- a/feature/main/src/main/java/com/school_of_company/main/viewmodel/MainViewModel.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/viewmodel/MainViewModel.kt
@@ -3,10 +3,14 @@ package com.school_of_company.main.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.school_of_company.data.repository.member.MemberRepository
 import com.school_of_company.data.repository.post.PostRepository
+import com.school_of_company.data.repository.review.ReviewRepository
 import com.school_of_company.main.viewmodel.uistate.GetMainListUiState
+import com.school_of_company.main.viewmodel.uistate.MemberUiState
 import com.school_of_company.model.enum.Mode
 import com.school_of_company.model.enum.Type
+import com.school_of_company.model.post.response.Member
 import com.school_of_company.result.asResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,6 +23,7 @@ import com.school_of_company.result.Result
 @HiltViewModel
 internal class MainViewModel @Inject constructor(
     private val postRepository: PostRepository,
+    private val memberRepository: MemberRepository
 ) : ViewModel() {
 
     private val _swipeRefreshLoading = MutableStateFlow(false)
@@ -26,6 +31,9 @@ internal class MainViewModel @Inject constructor(
 
     private val _getMainListUiState = MutableStateFlow<GetMainListUiState>(GetMainListUiState.Loading)
     val getMainListUiState = _getMainListUiState.asStateFlow()
+
+    private val _myProfileUiState = MutableStateFlow<MemberUiState>(MemberUiState.Loading)
+    internal val myProfileUiState = _myProfileUiState.asStateFlow()
 
     internal fun getMainList(
         type: Type,
@@ -53,6 +61,18 @@ internal class MainViewModel @Inject constructor(
                         _getMainListUiState.value = GetMainListUiState.Error(result.exception)
                         _swipeRefreshLoading.value = false
                     }
+                }
+            }
+    }
+
+    internal fun getMyProfile() = viewModelScope.launch {
+        memberRepository.getMyProfileInformation()
+            .asResult()
+            .collectLatest { result ->
+                when (result) {
+                    is Result.Loading -> _myProfileUiState.value = MemberUiState.Loading
+                    is Result.Success -> _myProfileUiState.value = MemberUiState.Success(result.data)
+                    is Result.Error -> _myProfileUiState.value = MemberUiState.Error(result.exception)
                 }
             }
     }

--- a/feature/main/src/main/java/com/school_of_company/main/viewmodel/uistate/MemberUiState.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/viewmodel/uistate/MemberUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.main.viewmodel.uistate
+
+import com.school_of_company.model.member.response.GetMemberResponseModel
+
+interface MemberUiState {
+    data object Loading : MemberUiState
+    data class Success(val data: GetMemberResponseModel) : MemberUiState
+    data class Error(val exception: Throwable) : MemberUiState
+}


### PR DESCRIPTION
## 💡 개요
- MainStartScreen, NoticeScreen에서 지점명을 가져와야하지만 고정값을 넣어두고 있던 문제가 있었습니다.
## 📃 작업내용
- MainStartScreen, NoticeScreen에 지점명을 표시해주었습니다.

     <img width="400" height="310" alt="스크린샷 2025-07-17 오후 5 49 13" src="https://github.com/user-attachments/assets/4ff969ea-559f-4137-abf8-f9d25741641e" />

     <img width="400" height="310" alt="스크린샷 2025-07-17 오후 5 49 34" src="https://github.com/user-attachments/assets/ade37e52-9cc8-4022-a5b3-5560c0a59ac9" />

## 🔀 변경사항
- add MemberUiState(:feature:inform && :feature:main)
- chore NoticeViewModel
- chore MainViewModel
- chore InformScreen
- chore MainStartScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile information is now dynamically fetched and displayed in both the Inform and Main screens, replacing previously static branch names.
  * UI updates in real-time to show loading indicators, fetched branch names, or error messages based on the profile fetch state.

* **Bug Fixes**
  * Improved error handling and user feedback when profile information fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->