### PR TITLE
🔀 :: (#179) - 알람 리스트를 눌러 거래완료를 할수 있게 구현했습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/gwangsan_android/navigation/GwangSanNavHost.kt
+++ b/app/src/main/java/com/school_of_company/gwangsan_android/navigation/GwangSanNavHost.kt
@@ -275,6 +275,11 @@ fun GwangsanNavHost(
 
         otherReviewScreen(onBackClick = { navController.popBackStack() })
 
-        noticeScreen(onBackClick = { navController.popBackStack() })
+        noticeScreen(
+            onBackClick = { navController.popBackStack() },
+            navigationToDetail = { id ->
+                navController.navigateToReadMore(id)
+            }
+        )
     }
 }

--- a/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
+++ b/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
@@ -333,7 +333,9 @@ private fun ReadMoreScreen(
                             color = colors.error,
                             modifier = Modifier
                                 .GwangSanClickable {
-                                    if (getSpecificPostUiState.post.isMine) setOpenDeleteBottomSheet(true) else setOpenReportBottomSheet(true)
+                                    if (getSpecificPostUiState.post.isMine) setOpenDeleteBottomSheet(
+                                        true
+                                    ) else setOpenReportBottomSheet(true)
                                 }
                                 .padding(horizontal = 24.dp)
                         )
@@ -369,10 +371,10 @@ private fun ReadMoreScreen(
                             } else {
                                 GwangSanStateButton(
                                     text = "거래하기",
-                                    state = when {
-                                        getSpecificPostUiState.post.isCompleted -> ButtonState.Disable
-                                        getSpecificPostUiState.post.isCompletable -> ButtonState.Enable
-                                        else -> ButtonState.Disable
+                                    state = if (getSpecificPostUiState.post.isCompletable == true) {
+                                        ButtonState.Enable
+                                    } else {
+                                        ButtonState.Disable
                                     },
                                     onClick = { onTransactionCompleteCallBack() },
                                     modifier = Modifier

--- a/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
+++ b/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
@@ -230,10 +230,6 @@ private fun ReadMoreScreen(
                 val post = getSpecificPostUiState.post
                 val pagerState = rememberPagerState(pageCount = { post.images.size })
 
-                Log.d("ReadMoreScreen", "✅ isCompleted: ${post.isCompleted}")
-                Log.d("ReadMoreScreen", "✅ isCompletable: ${post.isCompletable}")
-                Log.d("ReadMoreScreen", "✅ isPostTradeState: $isPostTradeState")
-
                 Box(
                     modifier = modifier
                         .fillMaxSize()

--- a/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
+++ b/feature/content/src/main/java/com/school_of_company/content/view/ReadMoreScreen.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.content.view
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -75,8 +76,6 @@ internal fun ReadMoreRoute(
     val (openDeleteBottomSheet, setOpenDeleteBottomSheet) = rememberSaveable { mutableStateOf(false) }
 
     val (buttonText, setButtonText) = remember { mutableStateOf("거래완료") }
-
-    val isPostTradeState = transactionCompleteUiState is TransactionCompleteUiState.Success
 
     LaunchedEffect(postId) {
         viewModel.getSpecificPost(postId)
@@ -193,7 +192,6 @@ internal fun ReadMoreRoute(
                 setOpenReportBottomSheet = setOpenReportBottomSheet,
                 setOpenReviewBottomSheet = setOpenReviewBottomSheet,
                 setOpenDeleteBottomSheet = setOpenDeleteBottomSheet,
-                isPostTradeState = isPostTradeState
             )
         }
     }
@@ -231,6 +229,10 @@ private fun ReadMoreScreen(
             is GetSpecificPostUiState.Success -> {
                 val post = getSpecificPostUiState.post
                 val pagerState = rememberPagerState(pageCount = { post.images.size })
+
+                Log.d("ReadMoreScreen", "✅ isCompleted: ${post.isCompleted}")
+                Log.d("ReadMoreScreen", "✅ isCompletable: ${post.isCompletable}")
+                Log.d("ReadMoreScreen", "✅ isPostTradeState: $isPostTradeState")
 
                 Box(
                     modifier = modifier
@@ -358,7 +360,7 @@ private fun ReadMoreScreen(
                                     .border(1.dp, colors.main500, RoundedCornerShape(8.dp))
                             )
 
-                            if (isPostTradeState) {
+                            if (post.isCompleted) {
                                 GwangSanStateButton(
                                     text = "리뷰쓰기",
                                     onClick = {

--- a/feature/main/src/main/java/com/school_of_company/main/component/NoticeList.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/component/NoticeList.kt
@@ -29,10 +29,11 @@ import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.design_system.component.clickable.GwangSanClickable
 import com.school_of_company.design_system.theme.GwangSanTheme
 import com.school_of_company.model.alert.response.GetAlertResponseModel
+import com.school_of_company.model.enum.AlertType
 
 @Composable
 fun NoticeListItem(
-    onClick: (Long, Long?) -> Unit,
+    onClick: (Long, Long?, alertType: AlertType) -> Unit,
     modifier: Modifier = Modifier,
     data: GetAlertResponseModel
 ) {
@@ -44,7 +45,7 @@ fun NoticeListItem(
             modifier = modifier
                 .background(color = color.white)
                 .fillMaxWidth()
-                .GwangSanClickable { onClick(data.sourceId, data.sendMemberId) }
+                .GwangSanClickable { onClick(data.sourceId, data.sendMemberId, data.alertType) }
         ) {
             Box(
                 modifier = Modifier
@@ -101,7 +102,7 @@ fun NoticeListItem(
 
 @Composable
 fun NoticeList(
-    onClick: (Long, Long?) -> Unit,
+    onClick: (Long, Long?, alertType: AlertType) -> Unit,
     modifier: Modifier = Modifier,
     items: List<GetAlertResponseModel>,
 ) {

--- a/feature/main/src/main/java/com/school_of_company/main/navgation/MainNavigation.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/navgation/MainNavigation.kt
@@ -67,10 +67,12 @@ fun NavGraphBuilder.mainStartScreen(
 
 fun NavGraphBuilder.noticeScreen(
     onBackClick: () -> Unit,
+    navigationToDetail: (Long) -> Unit
 ){
     composable(route = NoticeRoute){
         NoticeRoute(
             onBackClick = onBackClick,
+            navigationToDetail = navigationToDetail
         )
     }
 }

--- a/feature/main/src/main/java/com/school_of_company/main/view/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/view/NoticeScreen.kt
@@ -229,7 +229,6 @@ private fun NoticeScreen(
 
             }
             if (openBottomSheet) {
-
                 Dialog(onDismissRequest = { setOpenBottomSheet(false) }) {
                     GwangsanDialog(
                         onLogout = {

--- a/feature/main/src/main/java/com/school_of_company/main/view/NoticeScreen.kt
+++ b/feature/main/src/main/java/com/school_of_company/main/view/NoticeScreen.kt
@@ -40,11 +40,13 @@ import com.school_of_company.main.viewmodel.MainViewModel
 import com.school_of_company.main.viewmodel.uistate.GetAlertUiState
 import com.school_of_company.main.viewmodel.uistate.TransactionCompleteUiState
 import com.school_of_company.model.alert.response.GetAlertResponseModel
+import com.school_of_company.model.enum.AlertType
 import com.school_of_company.model.post.request.TransactionCompleteRequestModel
 
 @Composable
 internal  fun NoticeRoute(
     onBackClick: () -> Unit,
+    navigationToDetail: (Long) -> Unit,
     viewModel: MainViewModel = hiltViewModel()
 ){
 
@@ -78,7 +80,8 @@ internal  fun NoticeRoute(
         },
         transactionCompleteUiState = transactionCompleteUiState,
         openBottomSheet = openBottomSheet,
-        setOpenBottomSheet = setOpenBottomSheet
+        setOpenBottomSheet = setOpenBottomSheet,
+        navigationToDetail = navigationToDetail
     )
 }
 
@@ -90,12 +93,11 @@ private fun NoticeScreen(
     swipeRefreshState: SwipeRefreshState,
     openBottomSheet: Boolean,
     setOpenBottomSheet: (Boolean) -> Unit,
+    navigationToDetail: (Long) -> Unit,
     transactionCompleteUiState: TransactionCompleteUiState,
     getAlertCallBack: () -> Unit,
     onBackClick: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     val selectedSourceId = remember { mutableStateOf<Long?>(null) }
     val selectedMemberId = remember { mutableStateOf<Long?>(null) }
 
@@ -141,10 +143,16 @@ private fun NoticeScreen(
                         is GetAlertUiState.Success -> {
                             NoticeList(
                                 items = getAlertUiState.data,
-                                onClick = { sourceId, sendMemberId ->
-                                    selectedSourceId.value = sourceId
-                                    selectedMemberId.value = sendMemberId
-                                    setOpenBottomSheet(true)
+                                onClick = { sourceId, sendMemberId, alertType ->
+                                    if (alertType == AlertType.TRADE_COMPLETE) {
+                                        navigationToDetail(sourceId)
+                                    }else if(alertType == AlertType.OTHER_MEMBER_TRADE_COMPLETE) {
+                                        selectedSourceId.value = sourceId
+                                        selectedMemberId.value = sendMemberId
+                                        setOpenBottomSheet(true)
+                                    }else {
+                                        Unit
+                                    }
                                 },
                                 modifier = Modifier.fillMaxSize()
                             )
@@ -215,6 +223,7 @@ private fun NoticeScreen(
 
                         else -> Unit
                     }
+
                 }
 
 


### PR DESCRIPTION
## 💡 개요
알람 리스트를 눌러 거래완료를 할수 있게 구현했습니다.
## 📃 작업내용
alerttype에 따라  클릭할수 있게 했습니다
만약 alerttype 이 거래완료 라면 리뷰페이지로 넘어가게 구현했습니다

## 🔀 변경사항
<img width="885" height="239" alt="image" src="https://github.com/user-attachments/assets/582b210c-9b43-4d00-96cc-93217e29313f" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알림 목록에서 특정 알림 유형(예: 거래 완료)에 따라 상세 화면으로 바로 이동하거나, 다른 유형에 대해 하단 시트가 열리는 등 클릭 시 동작이 다양해졌습니다.
  * 알림 화면에서 상세 화면으로의 네비게이션 기능이 추가되었습니다.

* **버그 수정**
  * "리뷰쓰기" 버튼 표시 조건이 거래 완료 여부에 따라 더 정확하게 동작하도록 개선되었습니다.

* **기타**
  * 알림 목록 항목 클릭 시 알림 유형 정보를 함께 전달하도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->