### PR TITLE
🔀 :: (#195) - 난독화 설정을 해제하였습니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.io.FileInputStream
-import java.util.Properties
-
 plugins {
     id("gwangsan.android.application")
     id("gwangsan.android.hilt")
@@ -10,6 +7,14 @@ plugins {
 android {
     buildFeatures {
         buildConfig = true
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            isShrinkResources = false
+            signingConfig = signingConfigs.getByName("release")
+        }
     }
 
     packaging {
@@ -46,6 +51,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.messaging)
+    implementation(libs.firebase.crashlytics)
     implementation(libs.androidx.window.size)
     implementation(libs.androidx.navigation.runtime)
     implementation(libs.androidx.navigation.compose)
@@ -53,10 +59,4 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)
     implementation(libs.kotlinx.immutable)
-}
-fun getApiKey(propertyKey: String) : String {
-    val propFile = rootProject.file("./local.properties")
-    val properties = Properties()
-    properties.load(FileInputStream(propFile))
-    return properties.getProperty(propertyKey) ?: throw IllegalArgumentException("Property $propertyKey not found in local.properties")
 }

--- a/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
@@ -36,12 +36,21 @@ class AndroidApplicationConventionPlugin: Plugin<Project> {
                 // Enable Jetpack Compose feature for the project
                 buildFeatures.compose = true
 
+                signingConfigs {
+                    create("release") {
+                        storeFile = file("/Users/imyeonghun/Downloads/Gwangsan.jks")
+                        storePassword = "audgns@1716"
+                        keyAlias = "key0"
+                        keyPassword = "audgns@1617"
+                    }
+                }
+
                 buildTypes {
                     getByName("release") {
-                        isMinifyEnabled = true
-                        isShrinkResources = true
+                        isMinifyEnabled = false
+                        isShrinkResources = false
                         isDebuggable = false
-                        proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+                        signingConfig = signingConfigs.getByName("release")
                     }
                 }
 

--- a/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidFirebaseConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidFirebaseConventionPlugin.kt
@@ -19,14 +19,16 @@ class AndroidFirebaseConventionPlugin : Plugin<Project> {
             dependencies {
                 val bom = libs.findLibrary("firebase-bom").get()
                 add("implementation", platform(bom))
-                "implementation"(libs.findLibrary("firebase.analytics").get())
-                "implementation"(libs.findLibrary("firebase.crashlytics").get())
+                add("implementation", libs.findLibrary("firebase.analytics").get())
+                add("implementation", libs.findLibrary("firebase.crashlytics").get())
             }
 
+            // Crashlytics 설정: 릴리즈에서 매핑 업로드 비활성
             extensions.configure<ApplicationExtension> {
                 buildTypes.configureEach {
-                    configure<CrashlyticsExtension> {
-                        mappingFileUploadEnabled = name == "release"
+                    // Kotlin DSL 방식 CrashlyticsExtension 접근
+                    extensions.configure<CrashlyticsExtension> {
+                        mappingFileUploadEnabled = false
                     }
                 }
             }


### PR DESCRIPTION
## 💡 개요
- Retrofit 인터페이스, 모델 클래스 등에 -keep class 규칙을 proguard-rules.pro에 추가해야 정상 작동이 되었기 때문에 일단 배포 이후 난독화를 재적용하는 방향으로 하려합니다.
## 📃 작업내용
- 난독화를 필요로 하는 플러그인에서 난독화가 적용되지 않도록 수정하였습니다.
## 🔀 변경사항
- chore build.gradle.kts(app Module)
- chore AndroidFirebaseConventionPlugin
- chore AndroidApplicationConventionPlugin
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 릴리스 빌드 서명 구성을 추가하고 적용했습니다.
  - 릴리스 빌드에서 코드 축소와 리소스 축소를 비활성화했습니다.
  - Firebase Crashlytics를 추가하고 매핑 파일 업로드를 비활성화했습니다.
  - 종속성 선언 방식을 정리해 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->