### PR TITLE
🔀 :: (#226) - 지역선택하는 imepadding도 어색해 보여 삭제했습니다.

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/view/IntroduceScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/IntroduceScreen.kt
@@ -96,7 +96,6 @@ private fun IntroduceScreen(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .imePadding()
         ) {
             Column(
                 verticalArrangement = Arrangement.Top,

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
@@ -94,7 +94,6 @@ private fun PlaceNameScreen(
             modifier = modifier
                 .fillMaxSize()
                 .background(backgroundColor)
-                .imePadding()
                 .pointerInput(isDropdownVisible) {
                     detectTapGestures {
                         if (isDropdownVisible.value) {

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
@@ -207,7 +207,7 @@ private fun PlaceNameScreen(
 }
 
 
-@Preview(showBackground = true, name = "PlaceName - Empty (Disabled)")
+@Preview(showBackground = true, name = "PlaceName")
 @Composable
 private fun PlaceNameScreenPreview_Empty() {
     var place by rememberSaveable { mutableStateOf("") }


### PR DESCRIPTION
## 💡 개요
지역선택하는 imepadding도 어색해 보여 삭제했습니다.
## 📃 작업내용
지역선택하는 imepadding도 어색해 보여 삭제했습니다.
## 🔀 변경사항
<img width="1099" height="105" alt="image" src="https://github.com/user-attachments/assets/2112cc8c-0c87-49ea-bf53-9173150d07b8" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 화면 키보드 표시 시 자동 여백 처리를 제거하여 Introduce 및 장소명 입력 화면의 레이아웃 동작을 조정했습니다. 키보드가 올라올 때의 화면 요소 배치가 변경됩니다.
* 기타 작업
  * 장소명 입력 화면의 미리보기 이름을 정리했습니다. 런타임 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->