### PR TITLE
🔀 :: (#234) - 핸드폰이 작으면 전화번호 인증 입력 필드가 작아지는 문제를 해결했습니다.

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/view/CertinSignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/CertinSignUpScreen.kt
@@ -184,109 +184,100 @@ private fun CertinSignUpScreen(
     onPhoneNumberChange: (String) -> Unit,
     onCertificationNumberChange: (String) -> Unit,
 ) {
-
     GwangSanTheme { colors, typography ->
-
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top,
             modifier = modifier
                 .fillMaxSize()
-                .background(color = colors.white)
-                .padding(24.dp)
-                .verticalScroll(scrollState)
-                .pointerInput(Unit) {
-                    detectTapGestures { focusManager.clearFocus() }
-                }
+                .background(colors.white)
+                .imePadding()
         ) {
-            Spacer(modifier = Modifier.padding(top = 56.dp))
-
-            GwangSanTopBar(
-                startIcon = { DownArrowIcon(modifier = Modifier.GwangSanClickable { onBackClick() }) },
-                betweenText = "뒤로"
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = "회원가입",
-                style = typography.titleMedium2,
-                color = colors.black,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.align(Alignment.Start)
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = "전화번호를 입력해주세요",
-                style = typography.label,
-                color = colors.black.copy(alpha = 0.5f),
-                fontWeight = FontWeight.Normal,
-                modifier = Modifier.align(Alignment.Start)
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth()
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .verticalScroll(scrollState)
+                    .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
             ) {
-                GwangSanTextField(
-                    value = phoneNumber,
-                    label = "전화번호",
-                    placeHolder = "연락처는 \" - \" 빼고 입력해주세요",
-                    isDisabled = false,
-                    errorText = "",
-                    maxLines = 1,
-                    onTextChange = onPhoneNumberChange,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(70.dp)
+                Spacer(modifier = Modifier.height(56.dp))
+
+                GwangSanTopBar(
+                    startIcon = { DownArrowIcon(modifier = Modifier.GwangSanClickable { onBackClick() }) },
+                    betweenText = "뒤로"
                 )
 
-                GwangSanStateButton(
-                    text = "인증",
-                    state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
-                    modifier = Modifier
-                        .width(80.dp)
-                        .height(50.dp)
-                        .align(Alignment.Bottom)
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Text(
+                    text = "회원가입",
+                    style = typography.titleMedium2,
+                    color = colors.black,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "전화번호를 입력해주세요",
+                    style = typography.label,
+                    color = colors.black.copy(alpha = 0.5f),
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    sendCertificationCodeCallBack()
+                    GwangSanTextField(
+                        value = phoneNumber,
+                        label = "전화번호",
+                        placeHolder = "연락처는 \" - \" 빼고 입력해주세요",
+                        isDisabled = false,
+                        errorText = "",
+                        maxLines = 1,
+                        onTextChange = onPhoneNumberChange,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                    )
+
+                    GwangSanStateButton(
+                        text = "인증",
+                        state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(50.dp)
+                            .align(Alignment.Bottom)
+                    ) { sendCertificationCodeCallBack() }
                 }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                GwangSanTextField(
+                    value = certificationNumber,
+                    placeHolder = "인증번호를 입력해주세요",
+                    isError = isVerifyNumberError,
+                    isDisabled = false,
+                    errorText = "인증번호가 틀립니다.",
+                    onTextChange = {
+                        if (it.length <= 6 && it.all { c -> c.isDigit() }) onCertificationNumberChange(it)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    label = "전화번호 인증",
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
-            GwangSanTextField(
-                value = certificationNumber,
-                placeHolder = "인증번호를 입력해주세요",
-                isError = isVerifyNumberError,
-                isDisabled = false,
-                errorText = "인증번호가 틀립니다..",
-                onTextChange = {
-                    if (it.length <= 6 && it.all { char -> char.isDigit() }) onCertificationNumberChange(
-                        it
-                    )
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                label = "전화번호 인증",
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
-        Column(
-            verticalArrangement = Arrangement.Bottom,
-            modifier = Modifier
-                .fillMaxSize()
-                .imePadding()
-                .padding(
-                    start = 24.dp,
-                    end = 24.dp,
-                    bottom = 64.dp
-                ),
-        ) {
+            // 화면 가장 아래 고정 버튼 (스크롤 영역 바깥)
             GwangSanStateButton(
                 text = "인증하기",
                 state = when {
@@ -294,10 +285,13 @@ private fun CertinSignUpScreen(
                     certificationNumber.isNotBlank() -> ButtonState.Enable
                     else -> ButtonState.Disable
                 },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                certificationCallBack()
-            }
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 24.dp,
+                        vertical = 16.dp
+                    )
+            ) { certificationCallBack() }
         }
     }
 }
@@ -306,7 +300,7 @@ private fun CertinSignUpScreen(
 @Composable
 private fun CertinSignUpScreenPreview() {
     CertInSignUpRoute(
-        onErrorToast = {_, _ ->},
+        onErrorToast = { _, _ -> },
         onBackClick = {},
         onNeighborhoodClick = {}
     )


### PR DESCRIPTION
## 💡 개요
핸드폰이 작으면 전화번호 인증 입력 필드가 작아지는 문제를 해결했습니다.
## 📃 작업내용
fillmaxWidth 을 추가했습니다.
## 🔀 변경사항
<img width="933" height="99" alt="image" src="https://github.com/user-attachments/assets/e160b6f5-b497-4bd8-bd8c-ef7bc3ba84be" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 전화번호 입력란과 인증 버튼이 가로로 배열되어 한 줄에서 입력 및 인증 요청이 가능합니다.

* **스타일**
  * 화면 레이아웃이 개선되어 스크롤 가능한 영역과 하단 고정 버튼이 분리되어, 주요 인증 버튼(“인증하기”)이 항상 화면 하단에 고정되어 표시됩니다.
  * 인증번호 입력란이 개선되어 숫자만 입력할 수 있고, 최대 6자리로 제한됩니다.
  * 에러 메시지 및 입력 오류 처리 방식이 직관적으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->