### PR TITLE
🔀 :: (#242) -  마이프로필에서 내가 보낸후기리스트를 누르면 해당 게시글로 이동할 수 있게 변경 

### DIFF
--- a/app/src/main/java/com/school_of_company/gwangsan/navigation/GwangSanNavHost.kt
+++ b/app/src/main/java/com/school_of_company/gwangsan/navigation/GwangSanNavHost.kt
@@ -251,9 +251,17 @@ fun GwangsanNavHost(
             onErrorToast = onErrorToast
         )
 
-        myReviewScreen(onBackClick = { navController.popBackStack() })
+        myReviewScreen(
+            onBackClick = { navController.popBackStack() },
+            onPostClick = { id -> navController.navigateToReadMore(id) }
+        )
 
-        myWritingScreen(onBackClick = { navController.popBackStack() })
+
+        myWritingScreen(
+            onBackClick = { navController.popBackStack() },
+            onPostClick = { id -> navController.navigateToReadMore(id) }
+
+        )
 
         myWritingDetailScreen(
             onBackClick = { navController.popBackStack() },
@@ -264,7 +272,10 @@ fun GwangsanNavHost(
             }
         )
 
-        otherReviewScreen(onBackClick = { navController.popBackStack() })
+        otherReviewScreen(
+            onBackClick = { navController.popBackStack() },
+            onPostClick = { id -> navController.navigateToReadMore(id) }
+        )
 
         noticeScreen(
             onBackClick = { navController.popBackStack() },

--- a/feature/profile/src/main/java/com/school_of_company/profile/component/MyProfileReviewListItem.kt
+++ b/feature/profile/src/main/java/com/school_of_company/profile/component/MyProfileReviewListItem.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import com.school_of_company.design_system.component.clickable.GwangSanClickable
 import com.school_of_company.design_system.theme.GwangSanTheme
 import com.school_of_company.design_system.theme.color.GwangSanColor
 import com.school_of_company.profile.ui.model.ReviewResponseUi
@@ -32,13 +33,14 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun MyProfileReviewListItem(
     modifier: Modifier = Modifier,
     data: ReviewResponseUi,
-    onClick: () -> Unit = {}
+    onClick: (Long) -> Unit
 ) {
     GwangSanTheme { _, _ ->
         Card(
             colors = CardDefaults.cardColors(containerColor = Color.White),
-            onClick = onClick,
-            modifier = modifier.fillMaxWidth()
+            modifier = modifier
+                .GwangSanClickable { onClick(data.productId) }
+                .fillMaxWidth()
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -142,16 +144,3 @@ private fun MyProfileReviewProgressBar(
     }
 }
 
-@Preview
-@Composable
-private fun MyProfileReviewListItemPreview() {
-    MyProfileReviewListItem(
-        data = ReviewResponseUi(
-            productId = 0L,
-            content = "친절하고 응답도 빨랐어요. 다음에도 거래하고 싶습니다!",
-            light = 7, // 1~10
-            reviewerName = "김치라",
-            images = persistentListOf()
-        )
-    )
-}

--- a/feature/profile/src/main/java/com/school_of_company/profile/navigation/MyProfileNavigation.kt
+++ b/feature/profile/src/main/java/com/school_of_company/profile/navigation/MyProfileNavigation.kt
@@ -120,20 +120,24 @@ fun NavGraphBuilder.myProfileScreen(
 
 fun NavGraphBuilder.myReviewScreen(
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit
 ) {
     composable(route = MyReviewRoute) {
         MyReceiveReviewRoute(
             onBackClick = onBackClick,
+            onPostClick = onPostClick
         )
     }
 }
 
 fun NavGraphBuilder.myWritingScreen(
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit
 ) {
     composable(route = MyWritingRoute) {
         MyReviewRoute(
             onBackClick = onBackClick,
+            onPostClick = onPostClick,
         )
     }
 }
@@ -172,13 +176,15 @@ fun NavGraphBuilder.transactionHistoryScreen(
 
 fun NavGraphBuilder.otherReviewScreen(
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit
 ){
     composable( "$OtherReviewRoute/{memberId}"){ backStackEntry ->
         val memberId = backStackEntry.arguments?.getString("memberId")?.toLongOrNull() ?: return@composable
 
         OtherReviewRoute(
             onBackClick =  onBackClick,
-            memberId = memberId
+            memberId = memberId,
+            onPostClick = onPostClick
         )
     }
 }

--- a/feature/profile/src/main/java/com/school_of_company/profile/view/MyReceiveReviewScreen.kt
+++ b/feature/profile/src/main/java/com/school_of_company/profile/view/MyReceiveReviewScreen.kt
@@ -39,6 +39,7 @@ import kotlinx.collections.immutable.toPersistentSet
 @Composable
 internal fun MyReceiveReviewRoute(
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit,
     viewModel: MyProfileViewModel = hiltViewModel(),
 ) {
     val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle(
@@ -56,7 +57,8 @@ internal fun MyReceiveReviewRoute(
         onBackClick = onBackClick,
         getMyReviewUiState = getMyReviewUiState,
         getMyReceiveCallBack = { viewModel.getMyReview() },
-        swipeRefreshState = swipeRefreshState
+        swipeRefreshState = swipeRefreshState,
+        onPostClick = onPostClick
     )
 }
 
@@ -66,7 +68,9 @@ private fun MyReceiveReviewScreen(
     onBackClick: () -> Unit,
     getMyReviewUiState: GetMyReviewUiState,
     swipeRefreshState: SwipeRefreshState,
-    getMyReceiveCallBack: () -> Unit
+    getMyReceiveCallBack: () -> Unit,
+    onPostClick: (Long) -> Unit
+
 ) {
     GwangSanTheme { colors, typography ->
 
@@ -99,6 +103,7 @@ private fun MyReceiveReviewScreen(
                 when (getMyReviewUiState) {
                     is GetMyReviewUiState.Success -> {
                         MyReceiveReviewProfileList(
+                            onPostClick = onPostClick,
                             items = getMyReviewUiState.review.toPersistentList(),
                             modifier = Modifier
                                 .fillMaxSize()
@@ -165,6 +170,7 @@ private fun MyReceiveReviewScreen(
 @Composable
 fun MyReceiveReviewProfileList(
     items: PersistentList<ReviewResponseUi>,
+    onPostClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -172,7 +178,10 @@ fun MyReceiveReviewProfileList(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(items) { review ->
-            MyProfileReviewListItem(data = review)
+            MyProfileReviewListItem(
+                onClick = onPostClick,
+                data = review
+            )
         }
     }
 }

--- a/feature/profile/src/main/java/com/school_of_company/profile/view/MyReviewListScreen.kt
+++ b/feature/profile/src/main/java/com/school_of_company/profile/view/MyReviewListScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.collections.immutable.toPersistentList
 @Composable
 internal fun MyReviewRoute(
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit,
     viewModel: MyProfileViewModel = hiltViewModel()
 ) {
     val getMyWriteReviewUiState by viewModel.getMyWriteReviewUiState.collectAsStateWithLifecycle()
@@ -52,7 +53,8 @@ internal fun MyReviewRoute(
         onBackClick = onBackClick,
         getMyReviewUiState = getMyWriteReviewUiState,
         getMyReviewList = { viewModel.getMyWriteReview() },
-        swipeRefreshState = swipeRefreshState
+        swipeRefreshState = swipeRefreshState,
+        onPostClick = onPostClick
     )
 }
 
@@ -60,6 +62,7 @@ internal fun MyReviewRoute(
 private fun MyReviewScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit,
     getMyReviewUiState: GetMyReviewWriteUiState,
     swipeRefreshState: SwipeRefreshState,
     getMyReviewList: () -> Unit
@@ -96,6 +99,7 @@ private fun MyReviewScreen(
                 when (getMyReviewUiState) {
                     is GetMyReviewWriteUiState.Success -> {
                         MyReviewProfileList(
+                            onClick = onPostClick,
                             items = getMyReviewUiState.data.toPersistentList(),
                             modifier = Modifier
                                 .fillMaxSize()
@@ -162,6 +166,7 @@ private fun MyReviewScreen(
 @Composable
 fun MyReviewProfileList(
     items: List<ReviewResponseUi>,
+    onClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -170,6 +175,7 @@ fun MyReviewProfileList(
     ) {
         items(items) { review ->
             MyProfileReviewListItem(
+                onClick = onClick,
                 data = review,
             )
         }

--- a/feature/profile/src/main/java/com/school_of_company/profile/view/OtherReviewScreen.kt
+++ b/feature/profile/src/main/java/com/school_of_company/profile/view/OtherReviewScreen.kt
@@ -44,6 +44,7 @@ import kotlinx.collections.immutable.toPersistentList
 internal fun OtherReviewRoute(
     onBackClick: () -> Unit,
     memberId: Long,
+    onPostClick: (Long) -> Unit,
     viewModel: MyProfileViewModel = hiltViewModel()
 ) {
 
@@ -63,6 +64,7 @@ internal fun OtherReviewRoute(
         otherReviewUIState = getOtherReviewUiState,
         getMyReceiveCallBack = {viewModel.getOtherReview(memberId = memberId )},
         swipeRefreshState = swipeRefreshState,
+        onPostClick = onPostClick
     )
 }
 
@@ -70,6 +72,7 @@ internal fun OtherReviewRoute(
 private fun OtherReviewScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
+    onPostClick: (Long) -> Unit,
     otherReviewUIState: OtherReviewUIState,
     getMyReceiveCallBack: () -> Unit,
     swipeRefreshState: SwipeRefreshState,
@@ -115,6 +118,7 @@ private fun OtherReviewScreen(
                 when (otherReviewUIState) {
                     is OtherReviewUIState.Success -> {
                         OtherReviewScreenList(
+                            onPostClick = onPostClick,
                             items = otherReviewUIState.data.toPersistentList(),
                             modifier = Modifier
                                 .fillMaxSize()
@@ -181,7 +185,8 @@ private fun OtherReviewScreen(
 @Composable
 fun OtherReviewScreenList(
     items: PersistentList<ReviewResponseUi>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onPostClick: (Long) -> Unit
 ) {
     LazyColumn(
         modifier = modifier,
@@ -189,6 +194,7 @@ fun OtherReviewScreenList(
     ) {
         items(items) { review ->
             MyProfileReviewListItem(
+                onClick = onPostClick,
                 data = review,
             )
         }
@@ -202,6 +208,7 @@ private fun OtherReviewScreenPreview() {
         otherReviewUIState = OtherReviewUIState.Loading,
         onBackClick = {},
         getMyReceiveCallBack = {},
-        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false)
+        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        onPostClick = {}
     )
 }

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/CertinSignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/CertinSignUpScreen.kt
@@ -184,109 +184,100 @@ private fun CertinSignUpScreen(
     onPhoneNumberChange: (String) -> Unit,
     onCertificationNumberChange: (String) -> Unit,
 ) {
-
     GwangSanTheme { colors, typography ->
-
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Top,
             modifier = modifier
                 .fillMaxSize()
-                .background(color = colors.white)
-                .padding(24.dp)
-                .verticalScroll(scrollState)
-                .pointerInput(Unit) {
-                    detectTapGestures { focusManager.clearFocus() }
-                }
+                .background(colors.white)
+                .imePadding()
         ) {
-            Spacer(modifier = Modifier.padding(top = 56.dp))
-
-            GwangSanTopBar(
-                startIcon = { DownArrowIcon(modifier = Modifier.GwangSanClickable { onBackClick() }) },
-                betweenText = "뒤로"
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = "회원가입",
-                style = typography.titleMedium2,
-                color = colors.black,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.align(Alignment.Start)
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = "전화번호를 입력해주세요",
-                style = typography.label,
-                color = colors.black.copy(alpha = 0.5f),
-                fontWeight = FontWeight.Normal,
-                modifier = Modifier.align(Alignment.Start)
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth()
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .verticalScroll(scrollState)
+                    .pointerInput(Unit) { detectTapGestures { focusManager.clearFocus() } }
             ) {
-                GwangSanTextField(
-                    value = phoneNumber,
-                    label = "전화번호",
-                    placeHolder = "연락처는 \" - \" 빼고 입력해주세요",
-                    isDisabled = false,
-                    errorText = "",
-                    maxLines = 1,
-                    onTextChange = onPhoneNumberChange,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(70.dp)
+                Spacer(modifier = Modifier.height(56.dp))
+
+                GwangSanTopBar(
+                    startIcon = { DownArrowIcon(modifier = Modifier.GwangSanClickable { onBackClick() }) },
+                    betweenText = "뒤로"
                 )
 
-                GwangSanStateButton(
-                    text = "인증",
-                    state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
-                    modifier = Modifier
-                        .width(80.dp)
-                        .height(50.dp)
-                        .align(Alignment.Bottom)
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Text(
+                    text = "회원가입",
+                    style = typography.titleMedium2,
+                    color = colors.black,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "전화번호를 입력해주세요",
+                    style = typography.label,
+                    color = colors.black.copy(alpha = 0.5f),
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    sendCertificationCodeCallBack()
+                    GwangSanTextField(
+                        value = phoneNumber,
+                        label = "전화번호",
+                        placeHolder = "연락처는 \" - \" 빼고 입력해주세요",
+                        isDisabled = false,
+                        errorText = "",
+                        maxLines = 1,
+                        onTextChange = onPhoneNumberChange,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                    )
+
+                    GwangSanStateButton(
+                        text = "인증",
+                        state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(50.dp)
+                            .align(Alignment.Bottom)
+                    ) { sendCertificationCodeCallBack() }
                 }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                GwangSanTextField(
+                    value = certificationNumber,
+                    placeHolder = "인증번호를 입력해주세요",
+                    isError = isVerifyNumberError,
+                    isDisabled = false,
+                    errorText = "인증번호가 틀립니다.",
+                    onTextChange = {
+                        if (it.length <= 6 && it.all { c -> c.isDigit() }) onCertificationNumberChange(it)
+                    },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    label = "전화번호 인증",
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
-            GwangSanTextField(
-                value = certificationNumber,
-                placeHolder = "인증번호를 입력해주세요",
-                isError = isVerifyNumberError,
-                isDisabled = false,
-                errorText = "인증번호가 틀립니다..",
-                onTextChange = {
-                    if (it.length <= 6 && it.all { char -> char.isDigit() }) onCertificationNumberChange(
-                        it
-                    )
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                label = "전화번호 인증",
-                modifier = Modifier.fillMaxWidth()
-            )
-        }
-        Column(
-            verticalArrangement = Arrangement.Bottom,
-            modifier = Modifier
-                .fillMaxSize()
-                .imePadding()
-                .padding(
-                    start = 24.dp,
-                    end = 24.dp,
-                    bottom = 64.dp
-                ),
-        ) {
+            // 화면 가장 아래 고정 버튼 (스크롤 영역 바깥)
             GwangSanStateButton(
                 text = "인증하기",
                 state = when {
@@ -294,10 +285,13 @@ private fun CertinSignUpScreen(
                     certificationNumber.isNotBlank() -> ButtonState.Enable
                     else -> ButtonState.Disable
                 },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                certificationCallBack()
-            }
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 24.dp,
+                        vertical = 16.dp
+                    )
+            ) { certificationCallBack() }
         }
     }
 }
@@ -306,7 +300,7 @@ private fun CertinSignUpScreen(
 @Composable
 private fun CertinSignUpScreenPreview() {
     CertInSignUpRoute(
-        onErrorToast = {_, _ ->},
+        onErrorToast = { _, _ -> },
         onBackClick = {},
         onNeighborhoodClick = {}
     )

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/PlaceNameScreen.kt
@@ -155,7 +155,7 @@ private fun PlaceNameScreen(
                     Spacer(modifier = Modifier.height(8.dp))
 
                     SingleSelectDropdown(
-                        options = persistentListOf("수완세영", "수완마을", "신가", "신창", "도산", "우산", "월곡1", "첨단1", "평동", "월곡2", "하남"),
+                        options = persistentListOf("고실마을", "수완마을", "신가", "신창", "도산", "우산", "월곡1", "첨단2", "평동", "월곡2", "하남"),
                         selectedOption = placeName,
                         onOptionClick = onPlaceNameChange,
                         onDismissRequest = { isDropdownVisible.value = false },


### PR DESCRIPTION
## 💡 개요
 마이프로필에서 내가 보낸후기리스트를 누르면 해당 게시글로 이동할 수 있게 변경 
## 📃 작업내용
myReviewList에 onPostClick(id)를 추가하여 onPostClick이 되면 id로 해당하는 게시글을 조회할수 있습니다,.
## 🔀 변경사항
<img width="864" height="367" alt="image" src="https://github.com/user-attachments/assets/9fff3e18-895d-461f-9ca9-8aa19449e517" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 리뷰·내 글·다른 리뷰 목록에서 게시글을 탭하면 상세(더보기) 화면으로 이동할 수 있습니다.

- 개선
  - 메인 시작 화면 제목이 프로필의 거점 정보에 따라 동적으로 표시됩니다.
  - 휴대폰 인증 회원가입 화면 레이아웃을 재구성해 입력·인증 흐름을 단순화하고 하단 고정 “인증하기” 버튼을 추가했습니다.
  - 거점 선택 드롭다운의 기본 옵션 구성을 업데이트했습니다.

- 스타일
  - UI 여백, 스크롤 및 클릭 영역을 조정해 가독성과 사용성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->