### PR TITLE
🔀 :: (#256) - 게시글 작성 혹은 수정시 "팔아요"만 이미지를 필수로 해달라는 요청사항을 반영했습니다.

### DIFF
--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="error_bad_request">잘못된 요청입니다. 다시 시도해주세요.</string>
     <string name="error_resource_not_found">리소스를 찾을 수 없습니다. 요청한 데이터를 확인해주세요.</string>
     <string name="error_too_many_requests">요청이 너무 많습니다. 잠시 후 다시 시도해주세요.</string>
+    <string name="require_image">이미지를 추가해주세요.</string>
 
     
    <string name="success_post">게시를 성공했습니다.</string>

--- a/feature/post/src/main/java/com/school_of_company/post/view/PostFinalScreen.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/view/PostFinalScreen.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.post.view
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -69,7 +70,6 @@ internal fun PostFinalRoute(
 
     val context = LocalContext.current
 
-
     LaunchedEffect(postUiState) {
         when (postUiState) {
             is PostUiState.Loading -> Unit
@@ -80,8 +80,8 @@ internal fun PostFinalRoute(
             }
             is PostUiState.BadRequest -> onErrorToast(null, R.string.error_bad_request)
             is PostUiState.NotFound -> onErrorToast(null, R.string.error_resource_not_found)
-            is PostUiState.Error ->
-                onErrorToast((postUiState as PostUiState.Error).exception, R.string.error_generic)
+            is PostUiState.Error -> onErrorToast((postUiState as PostUiState.Error).exception, R.string.error_generic)
+            is PostUiState.NotFoundImage -> onErrorToast(null, R.string.require_image)
             else -> Unit
         }
     }
@@ -97,6 +97,7 @@ internal fun PostFinalRoute(
             is ModifyPostUiState.Error -> {
                 makeToast(context, "게시글 수정 실패")
             }
+            is ModifyPostUiState.NotFoundImage -> onErrorToast(null, R.string.require_image)
             else -> Unit
         }
     }
@@ -111,6 +112,7 @@ internal fun PostFinalRoute(
     }
 
     PostFinalScreen(
+        context = context,
         subject = subject,
         content = content,
         price = price,
@@ -132,6 +134,7 @@ internal fun PostFinalRoute(
 @Composable
 private fun PostFinalScreen(
     modifier: Modifier = Modifier,
+    context: Context,
     subject: String,
     content: String,
     price: String,
@@ -312,7 +315,13 @@ private fun PostFinalScreen(
                     GwangSanStateButton(
                         text = "완료",
                         state = ButtonState.Enable,
-                        onClick = onSubmitClick,
+                        onClick = {
+                            if (modeLabel == "팔아요" && typeLabel == "물건" && images.isEmpty()) {
+                                makeToast(context, "이미지를 첨부해주세요.")
+                            } else {
+                                onSubmitClick()
+                            }
+                        },
                         modifier = Modifier
                             .weight(1f)
                             .height(56.dp)
@@ -337,6 +346,7 @@ private fun PostFinalPreview() {
         onBackClick = {},
         images = persistentListOf(),
         typeLabel = "물건",
-        modeLabel = "필요해요"
+        modeLabel = "필요해요",
+        context = LocalContext.current
     )
 }

--- a/feature/post/src/main/java/com/school_of_company/post/view/PostInputScreen.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/view/PostInputScreen.kt
@@ -211,10 +211,10 @@ private fun PostInputScreen(
 
             val canProceed = when {
                 value.isBlank() -> false
-                !hasAnyImage -> false
                 imageUri.isEmpty() -> true
+                imageUpLoadUiState is ImageUpLoadUiState.Loading -> false
                 imageUpLoadUiState is ImageUpLoadUiState.Success -> true
-                else -> false
+                else -> true
             }
 
             GwangSanStateButton(

--- a/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
@@ -161,8 +161,11 @@ class PostViewModel @Inject constructor(
                         _editPostId.value = null
                     }
                     is Result.Error -> {
-                        _modifyPostUiStat.value = ModifyPostUiState.Error(result.exception)
-                        Log.e("ModifyPostViewModel", "Error: ${result.exception}")
+                        if (mode.value.name == Mode.GIVER.name && imageIds.value.isEmpty()) {
+                            _modifyPostUiStat.value = ModifyPostUiState.NotFoundImage
+                        } else {
+                            _modifyPostUiStat.value = ModifyPostUiState.Error(result.exception)
+                        }
                     }
                 }
             }
@@ -191,11 +194,15 @@ class PostViewModel @Inject constructor(
             when (result) {
                 is Result.Success -> _postUiState.value = PostUiState.Success
                 is Result.Error -> {
-                    _postUiState.value = PostUiState.Error(result.exception)
                     result.exception.errorHandling(
                         badRequestAction = { PostUiState.BadRequest },
                         notFoundAction = { PostUiState.NotFound },
                     )
+                    if (mode.value.name == Mode.GIVER.name && imageIds.value.isEmpty()) {
+                        _postUiState.value = PostUiState.NotFoundImage
+                    } else {
+                        _postUiState.value = PostUiState.Error(result.exception)
+                    }
                 }
                 is Result.Loading -> _postUiState.value = PostUiState.Loading
             }

--- a/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
@@ -161,7 +161,7 @@ class PostViewModel @Inject constructor(
                         _editPostId.value = null
                     }
                     is Result.Error -> {
-                        if (mode.value.name == Mode.GIVER.name && imageIds.value.isEmpty()) {
+                        if (mode.value.name == Mode.GIVER.name && type.value.name == Type.OBJECT.name && imageIds.value.isEmpty()) {
                             _modifyPostUiStat.value = ModifyPostUiState.NotFoundImage
                         } else {
                             _modifyPostUiStat.value = ModifyPostUiState.Error(result.exception)
@@ -198,7 +198,7 @@ class PostViewModel @Inject constructor(
                         badRequestAction = { PostUiState.BadRequest },
                         notFoundAction = { PostUiState.NotFound },
                     )
-                    if (mode.value.name == Mode.GIVER.name && imageIds.value.isEmpty()) {
+                    if (mode.value.name == Mode.GIVER.name && type.value.name == Type.OBJECT.name && imageIds.value.isEmpty()) {
                         _postUiState.value = PostUiState.NotFoundImage
                     } else {
                         _postUiState.value = PostUiState.Error(result.exception)

--- a/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/viewmodel/PostViewModel.kt
@@ -161,7 +161,7 @@ class PostViewModel @Inject constructor(
                         _editPostId.value = null
                     }
                     is Result.Error -> {
-                        if (mode.value.name == Mode.GIVER.name && type.value.name == Type.OBJECT.name && imageIds.value.isEmpty()) {
+                        if (mode.value == Mode.GIVER && type.value == Type.OBJECT && imageIds.value.isEmpty()) {
                             _modifyPostUiStat.value = ModifyPostUiState.NotFoundImage
                         } else {
                             _modifyPostUiStat.value = ModifyPostUiState.Error(result.exception)
@@ -198,7 +198,7 @@ class PostViewModel @Inject constructor(
                         badRequestAction = { PostUiState.BadRequest },
                         notFoundAction = { PostUiState.NotFound },
                     )
-                    if (mode.value.name == Mode.GIVER.name && type.value.name == Type.OBJECT.name && imageIds.value.isEmpty()) {
+                    if (mode.value == Mode.GIVER && type.value == Type.OBJECT && imageIds.value.isEmpty()) {
                         _postUiState.value = PostUiState.NotFoundImage
                     } else {
                         _postUiState.value = PostUiState.Error(result.exception)

--- a/feature/post/src/main/java/com/school_of_company/post/viewmodel/uiState/ModifyPostUiState.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/viewmodel/uiState/ModifyPostUiState.kt
@@ -3,5 +3,7 @@ package com.school_of_company.post.viewmodel.uiState
 interface ModifyPostUiState {
     data object Loading : ModifyPostUiState
     data object Success : ModifyPostUiState
+    data object NotFoundImage : ModifyPostUiState
+
     data class Error(val exception: Throwable) : ModifyPostUiState
 }

--- a/feature/post/src/main/java/com/school_of_company/post/viewmodel/uiState/PostUiState.kt
+++ b/feature/post/src/main/java/com/school_of_company/post/viewmodel/uiState/PostUiState.kt
@@ -5,5 +5,6 @@ sealed interface PostUiState {
     data object Success : PostUiState
     data object BadRequest : PostUiState
     data object NotFound : PostUiState
+    data object NotFoundImage : PostUiState
     data class Error(val exception: Throwable) : PostUiState
 }


### PR DESCRIPTION
## 💡 개요
- 게시글 작성 혹은 수정시 "팔아요"만 이미지를 필수로 해달라는 요청사항이 있어 수정이 필요했습니다.
## 📃 작업내용
- Type - "물건", Mode - "팔아요" 통신시 ImageIds 배열이 Empty 상태라면 NotFoundImage라는 에러를 뱉고 이미지를 추가해달라는 토스트 메세지를 보여줍니다.
- PostInputScreen에서는 모드에 따라서 처리하는 로직을 포함하지 않고 이미지 업로드 로딩중일때와 광산 값이 입력되지 않았을때만 False를 봔환 하도록 하였습니다.
## 🔀 변경사항
- chore strings.xml(:core:design-system)
- chore PostFinalScreen
- chore PostInputScreen
- chore PostViewModel
- chore PostUiState
- chore ModifyPostUiState
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 물건 판매 게시물 작성/수정 시 이미지가 없으면 별도 상태로 분류하여 사용자에게 이미지 추가를 안내
  * 최종 제출 시 이미지 누락 조건에 대해 즉시 토스트 안내 표시
  * 사용자 문구 추가: "이미지를 추가해주세요." 메시지 제공

* **버그 수정**
  * 이미지 업로드 중에는 진행 불가하도록 검증 강화
  * 이미지 관련 오류 상태가 보다 명확하게 분류 및 처리되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->