### PR TITLE
🔀 :: (#260) - 사용자들이 회원가입시 이름, 별칭 등에 띄어쓰기 쓰는 경우가 많아 이를 trim()으로 처리했습니다.

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -236,19 +236,19 @@ class SignUpViewModel @Inject constructor(
     }
 
     fun onNameChange(value: String) {
-        savedStateHandle[NAME] = value
+        savedStateHandle[NAME] = value.trim()
     }
 
     internal fun onNicknameChange(value: String) {
-        savedStateHandle[NICKNAME] = value
+        savedStateHandle[NICKNAME] = value.trim()
     }
 
     internal fun onPasswordChange(value: String) {
-        savedStateHandle[PASSWORD] = value
+        savedStateHandle[PASSWORD] = value.trim()
     }
 
     internal fun onCheckPasswordChange(value: String) {
-        savedStateHandle[RE_PASSWORD] = value
+        savedStateHandle[RE_PASSWORD] = value.trim()
     }
 
     internal fun onNumberChange(value: String) {
@@ -268,7 +268,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     internal fun onRecommenderChange(value: String) {
-        savedStateHandle[RECOMMENDER] = value
+        savedStateHandle[RECOMMENDER] = value.trim()
     }
 
     internal fun onSpecialtyListChange(list: List<String>) {

--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -244,11 +244,11 @@ class SignUpViewModel @Inject constructor(
     }
 
     internal fun onPasswordChange(value: String) {
-        savedStateHandle[PASSWORD] = value.trim()
+        savedStateHandle[PASSWORD] = value
     }
 
     internal fun onCheckPasswordChange(value: String) {
-        savedStateHandle[RE_PASSWORD] = value.trim()
+        savedStateHandle[RE_PASSWORD] = value
     }
 
     internal fun onNumberChange(value: String) {


### PR DESCRIPTION
## 💡 개요
- 회원가입시 이름, 별칭에 띄어쓰기가 들어가면 서버 에러가 일어나기 때문에 회원가입을 성공적으로 마칠 수 없습니다.
   - 사용자들은 해당 문제를 파악하기 어렵기 때문에 trim() 처리를 하여 해당 문제가 발생하지 않도록 하면 사용자 경험이 향상될것이라 생각했습니다.
## 📃 작업내용
- 회원가입 절차별로 띄어쓰기가 들어가면 안되는 부분에 ViewModel에서 처리되고 있는 onTextChange에 trim() 처리를 해주었습니다.
## 🔀 변경사항
- chore SignUpViewModel
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회원가입 입력 필드 중 이름, 닉네임, 추천인 입력값의 앞뒤 공백을 자동으로 제거하도록 개선했습니다.  
  * 비밀번호 및 확인 비밀번호 필드는 기존 동작을 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->