### PR TITLE
🔀 :: (#262) - 회원가입 성공하고 처음 로그인 화면으로 이동 이후 네비게이션 백스택을 삭제하도록 수정했습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/gwangsan/navigation/GwangSanNavHost.kt
+++ b/app/src/main/java/com/school_of_company/gwangsan/navigation/GwangSanNavHost.kt
@@ -162,7 +162,7 @@ fun GwangsanNavHost(
         )
 
         signUpFinishScreen(
-            onClickGoToLogin = { navController.navigateToSignIn() }
+            onClickGoToLogin = { navController.navigationPopUpToLogin(loginRoute = StartRoute) }
         )
 
         mainScreen(

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/FinishScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/FinishScreen.kt
@@ -20,7 +20,6 @@ internal fun FinishRoute(
     FinishScreen(onClickGoToLogin = onClickGoToLogin)
 }
 
-
 @Composable
 fun FinishScreen(
     modifier: Modifier = Modifier,


### PR DESCRIPTION
## 💡 개요
- 회원가입 성공이후 로그인 화면으로 진입한 뒤에 뒤로가기를 하면 회원가입 화면으로 다시 이동이 되어 사용자 경험이 떨어질 수 있다고 생각하였습니다.
## 📃 작업내용
- navigationPopUpToLogin 함수를 사용하여 로그인 화면으로 진입시 모든 백스택을 초기화 하도록 수정했습니다.(회원가입 부분만)
## 🔀 변경사항
- chore GwangSanNavHost
- chore FinishScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 회원가입 완료 후 로그인 화면으로의 이동 흐름을 개선했습니다.

* **기타**
  * 코드 정리 및 불필요한 공백을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->